### PR TITLE
Add rpm spec file

### DIFF
--- a/46sshd/module-setup.sh
+++ b/46sshd/module-setup.sh
@@ -65,6 +65,10 @@ install() {
     # include those files
     inst_multiple -o /etc/systemd/network/*
 
+    # Add command to unlock luks volumes to bash history for easier use
+    echo "systemd-tty-ask-password-agent" >> "$initdir/root/.bash_history"
+    chmod 600 "$initdir/root/.bash_history"
+
     return 0
 }
 

--- a/46sshd/sshd_config
+++ b/46sshd/sshd_config
@@ -7,6 +7,7 @@ GSSAPIAuthentication no
 GSSAPICleanupCredentials no
 UsePAM no
 X11Forwarding no
+AuthenticationMethods publickey
 
 AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
 AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT

--- a/dracut-sshd.spec
+++ b/dracut-sshd.spec
@@ -1,0 +1,37 @@
+Name:       {{{ git_dir_name }}}
+Version:    {{{ git_dir_version }}}
+Release:    1%{?dist}
+Summary:    Add sshd to your initramfs
+
+License:    GPLv3+
+VCS:        {{{ git_dir_vcs }}}
+
+Source:     {{{ git_dir_pack }}}
+BuildArch:  noarch
+%define debug_package %{nil}
+Requires:   dracut-network
+
+%description
+Add sshd to your initramfs
+
+%prep
+{{{ git_dir_setup_macro }}}
+
+%build
+# nothing to do here
+
+%install
+rm -rf %{buildroot}
+mkdir -p %{buildroot}/usr/lib/dracut/modules.d/
+mv 46sshd %{buildroot}/usr/lib/dracut/modules.d/
+
+%clean
+rm -rf %{buildroot}
+
+%files
+%attr(755, root, root) /usr/lib/dracut/modules.d/46sshd/module-setup.sh
+%attr(644, root, root) /usr/lib/dracut/modules.d/46sshd/sshd.service
+%attr(644, root, root) %config(noreplace) /usr/lib/dracut/modules.d/46sshd/sshd_config
+
+%changelog
+


### PR DESCRIPTION
This adds a spec file so we can build rpm files for Fedora and CentOS
https://copr.fedorainfracloud.org/coprs/champtar/dracut-sshd/

If you want to manually build it you need to use "rpkg"