### PR TITLE
Use dracut_authorized_keys if present

### DIFF
--- a/46sshd/module-setup.sh
+++ b/46sshd/module-setup.sh
@@ -39,7 +39,11 @@ install() {
         fi
     done
 
-    authorized_keys=/root/.ssh/authorized_keys
+    if [ -e /root/.ssh/dracut_authorized_keys ]; then
+        authorized_keys=/root/.ssh/dracut_authorized_keys
+    else
+        authorized_keys=/root/.ssh/authorized_keys
+    fi
     if [ ! -r "$authorized_keys" ]; then
         dfatal "No authorized_keys for root user found!"
         return 1

--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ keys, as it's included in the [initramfs][iramfs]:
 
     # cat /root/.ssh/authorized_keys
 
+That said, if `/root/.ssh/dracut_authorized_keys` is present
+then it is included, instead.
+
 Create a non-[NetworkManager][nm] network config, e.g. via
 [Networkd][networkd]:
 


### PR DESCRIPTION
If present, use `/root/.ssh/dracut_authorized_keys` instead of `/root/.ssh/authorized_keys`.

It allows different keys to be used to log into the initramfs and the fully booted system.

This follows the same logic as for `/etc/ssh/dracut_ssh_host_*_key{,.pub}`.

