### PR TITLE
add quiet flag to systemctl

### DIFF
--- a/46sshd/module-setup.sh
+++ b/46sshd/module-setup.sh
@@ -74,7 +74,7 @@ install() {
         mkdir -p -m 0755 "$initdir/var/lib/empty"
     fi
 
-    systemctl --root "$initdir" enable sshd
+    systemctl -q --root "$initdir" enable sshd
 
     # as of Fedora 28, the systemd-networkd dracut module doesn't
     # include those files


### PR DESCRIPTION
This change brings dracut-sshd in line with upstream dracut's
configuration for enabling systemd services.

See for example [modules.d/00systemd](https://github.com/dracutdevs/dracut/blob/master/modules.d/00systemd/module-setup.sh#L244-L246)