### PR TITLE
add /var/log/lastlog for sshd login information

### DIFF
--- a/46sshd/module-setup.sh
+++ b/46sshd/module-setup.sh
@@ -91,6 +91,10 @@ install() {
     echo systemd-tty-ask-password-agent >> "$initdir/root/.bash_history"
     chmod 600 "$initdir/root/.bash_history"
 
+    # sshd requires /var/log/lastlog for tracking login information
+    mkdir -p -m 0755 "$initdir/var/log"
+    touch "$initdir/var/log/lastlog"
+
     return 0
 }
 


### PR DESCRIPTION
sshd requires this file for getting information on the last login
for the current user. This change will only append to the current
file if it exists.