### PR TITLE
Remove networkd globbing

### DIFF
--- a/46sshd/module-setup.sh
+++ b/46sshd/module-setup.sh
@@ -83,10 +83,6 @@ install() {
 
     systemctl -q --root "$initdir" enable sshd
 
-    # as of Fedora 28, the systemd-networkd dracut module doesn't
-    # include those files
-    inst_multiple -o /etc/systemd/network/*
-
     # Add command to unlock luks volumes to bash history for easier use
     echo systemd-tty-ask-password-agent >> "$initdir/root/.bash_history"
     chmod 600 "$initdir/root/.bash_history"

--- a/README.md
+++ b/README.md
@@ -118,9 +118,11 @@ parameters, see below).  However, the author of this README
 strongly recommends to use Networkd instead of NetworkManager on
 servers and server-like systems.
 
-If the above example is sufficient you can install it via:
+If the above example is sufficient you can copy the drop-in config
+file in `/etc/dracut.conf.d/`:
 
     # cp example/20-wired.network  /etc/systemd/network
+    # cp example/90-networkd.conf /etc/dracut.conf.d
 
 Finally regenerate the initramfs:
 
@@ -405,4 +407,3 @@ Related ticket: [Bug 524727 - Dracut + encrypted root + networking (2009)][bug52
 [dradd]: https://manpath.be/f30/8/dracut#L94
 [port]: https://github.com/gsauthof/dracut-sshd/issues/9#issuecomment-531308602
 [entropy]: https://github.com/gsauthof/dracut-sshd/issues/12
-

--- a/ci/install-dracut-sshd.sh
+++ b/ci/install-dracut-sshd.sh
@@ -35,6 +35,9 @@ done
 scp -r -P $port "${ssh_flags[@]}" \
     "$base"/46sshd root@"$host":/usr/lib/dracut/modules.d
 
+scp -r -P $port "${ssh_flags[@]}" \
+    "$base"/example/90-networkd.conf root@"$host":/etc/dracut.conf.d
+
 if [ "$with_extra_keys" = y ]; then
     ssh -p $port "${ssh_flags[@]}" root@"$host" \
         cp 'dracut_ssh_host_*_key*' /etc/ssh

--- a/example/90-networkd.conf
+++ b/example/90-networkd.conf
@@ -1,0 +1,5 @@
+# copy to /etc/dracut.conf.d/90-networkd.conf
+# You may add any other networkd files by appending them
+# to install_items
+
+install_items+=" /etc/systemd/network/20-wired.network "


### PR DESCRIPTION
removes the automatic inclusion of networkd files from the initramfs. README and CI changes are also included.

Closes #23 