### PR TITLE
Give users better hints after logging in

### DIFF
--- a/46sshd/module-setup.sh
+++ b/46sshd/module-setup.sh
@@ -52,6 +52,9 @@ install() {
     /usr/bin/install -m 600 "$authorized_keys" \
             "$initdir/root/.ssh/authorized_keys"
 
+    /usr/bin/install -m 600 "${moddir}/profile" \
+            "$initdir/root/.profile"
+
     inst_binary /usr/sbin/sshd
     inst_multiple -o /etc/sysconfig/sshd /etc/sysconfig/ssh \
             /etc/sysconfig/dracut-sshd

--- a/46sshd/profile
+++ b/46sshd/profile
@@ -1,0 +1,15 @@
+if [ -n "$SSH_TTY" ]; then
+  export PS1="initramfs-ssh:\${PWD}# "
+  cat << EOF
+
+Welcome to the early boot SSH environment. Please type
+
+  systemd-tty-ask-password-agent
+
+(or press "arrow up") to unlock your disks and continue
+the boot process. This shell will terminate automatically
+a few seconds after the unlocking process has succeeded.
+
+EOF
+fi
+


### PR DESCRIPTION
After some discussion, this uses .profile now.

~Add a script to be executed custom ssh command. It issues
a header with helpful instructions and spawns a regular
interactive login shell.~

~Using .profile has too much potential of breaking things
and I did not want to touch the SSH config, so a command=
statement gets prefixed for every key that is added to
the initrd.~