### PR TITLE
Silverblue workaround extended to others ostree os

### DIFF
--- a/46sshd/module-setup.sh
+++ b/46sshd/module-setup.sh
@@ -80,8 +80,8 @@ install() {
             break
         fi
     done
-    # workaround for Silverblue mount points https://github.com/coreos/rpm-ostree/issues/2325
-    if grep ^VARIANT_ID=silverblue$ /etc/os-release > /dev/null; then
+    # workaround for Silverblue (in general for ostree based os)
+    if grep ^OSTREE_VERSION= /etc/os-release > /dev/null; then
         mkdir -p -m 0755 "$initdir/var/empty/sshd"
     fi
 


### PR DESCRIPTION
The module on Fedora IoT does not work for the same problem for which it did not work on Silverblue; in particular the daemon does not start due to the missing folder `/var/empty/sshd` in the initramfs. So, I extended the workaround in the `46sshd/module-setup.sh` for Silverblue to all the os based on ostree.

I tested this "improvement" on fedora IoT and also on Silverblue to check that the change does not broke the old workaround.
I did not test it on other os based on ostree but in the best case this woks with all system based on ostree, in the worst one this works on Fedora IoT without broke the Silverblue workaround.

Currently I am using this workaround on my machines.