### PR TITLE
Create /etc/shadow if does not exist

### DIFF
--- a/46sshd/module-setup.sh
+++ b/46sshd/module-setup.sh
@@ -64,6 +64,11 @@ install() {
     inst_simple "${moddir}/sshd.service" "$systemdsystemunitdir/sshd.service"
     inst_simple "${moddir}/sshd_config" /etc/ssh/sshd_config
 
+    # When the flag hostonly is no set, /etc/shadow will not exist
+    if [ ! -f "$initdir/etc/shadow" ]; then
+        echo 'root::::::::' >> "$initdir/etc/shadow"
+    fi
+
     { grep '^sshd:' $dracutsysrootdir/etc/passwd || echo 'sshd:x:74:74:Privilege-separated SSH:/var/empty/sshd:/sbin/nologin'; } >> "$initdir/etc/passwd"
     { grep '^sshd:' $dracutsysrootdir/etc/group  || echo 'sshd:x:74:'; } >> "$initdir/etc/group"
 


### PR DESCRIPTION
This behavior is expected when the flag hostonly is no set as true. https://github.com/dracutdevs/dracut/blob/260883d96f33e7aced3d00c85d0ebffcec1385a1/modules.d/99base/module-setup.sh#L38