### PR TITLE
Create /run/sshd under systemd using RuntimeDirectory

### DIFF
--- a/46sshd/module-setup.sh
+++ b/46sshd/module-setup.sh
@@ -72,26 +72,16 @@ install() {
     # /usr/share/empty.sshd -> Fedora >= 34
     # /var/emtpy            -> Arch, OpenSSH upstream
     # /var/lib/empty        -> Suse
-    # /run/sshd             -> Debian, Ubuntu
     # /var/chroot/ssh       -> Void Linux
     local d
-    for d in /var/empty/sshd /usr/share/empty.sshd /var/empty /var/lib/empty /run/sshd /var/chroot/ssh ; do
+    for d in /var/empty/sshd /usr/share/empty.sshd /var/empty /var/lib/empty /var/chroot/ssh ; do
         if [ -d "$d" ]; then
             mkdir -p -m 0755 "$initdir$d"
-
-            # redundant on most distriubtions, but required on Ubuntu 20.04.2
-            echo "d $d 0755 root root -" > "$initdir$tmpfilesdir/sshd-tmpfiles.conf"
-            break
         fi
     done
     # workaround for Silverblue (in general for ostree based os)
     if grep ^OSTREE_VERSION= /etc/os-release > /dev/null; then
         mkdir -p -m 0755 "$initdir/var/empty/sshd"
-    fi
-
-    # workaround for Ubuntu not extracing /run from initramfs
-    if grep ^ID=ubuntu /etc/os-release > /dev/null; then
-        sed -i '/Before=cryptsetup.target/a After=systemd-tmpfiles-setup.service     # required on Ubuntu 20.04' "$systemdsystemunitdir/sshd.service"
     fi
 
     systemctl -q --root "$initdir" enable sshd

--- a/46sshd/sshd.service
+++ b/46sshd/sshd.service
@@ -29,5 +29,9 @@ KillMode=process
 Restart=on-failure
 RestartSec=42s
 
+# Create privilege separation directory /run/sshd for Debian/Ubuntu
+RuntimeDirectory=sshd
+RuntimeDirectoryMode=0755
+
 [Install]
 WantedBy=sysinit.target


### PR DESCRIPTION
On Debian 12 (Bookworm) and older releases `sshd.service` fails to start with error message `Missing privilege separation directory: /run/sshd` (similar to issue #18).

[Commit 2dbc272](https://github.com/gsauthof/dracut-sshd/commit/2dbc272ea6e1a0719968ff61bceff5d22513b1ab) does not work on systems where /run is a tmpfs, so use [systemd's `RuntimeDirectory`](https://www.freedesktop.org/software/systemd/man/systemd.exec.html) instead, as [done in Debian](https://salsa.debian.org/ssh-team/openssh/-/commit/4c771b9c7f2f9c5ddd0aefdbfb16441c2d7969a9).
