### PR TITLE
Fixup /etc/shadow to allow ssh pubkey login with disabled password

### DIFF
--- a/99sshd-shadow-fixup/module-setup.sh
+++ b/99sshd-shadow-fixup/module-setup.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# 2023, Warren Togami <wtogami@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# called by dracut
+check() {
+    require_binaries sshd || return 1
+    # 0 enables by default, 255 only on request
+    return 0
+}
+
+# called by dracut
+depends() {
+    return 0
+}
+
+# called by dracut
+install() {
+    # /etc/shadow "root:!:" allows for ssh pubkey logins on a normal system. 
+    # dracut-sshd "UsePAM no" is incompatible with a '!'. Fixup to '*' which allows ssh pubkey login to work as intended.
+    grep '^root:!:' "$initdir/etc/shadow" -q && sed -i -e 's/^root:!:/root:*:/' "$initdir/etc/shadow"
+
+    return 0
+}
+

--- a/dracut-sshd.spec
+++ b/dracut-sshd.spec
@@ -4,7 +4,7 @@ Name:       {{{ git_dir_name }}}
 # the 'lead' parameter, anyways
 # cf. https://pagure.io/rpkg-util/issue/21#comment-601077
 #Version:    {{{ git_dir_version }}}
-Version:    0.6.5
+Version:    0.6.6
 Release:    1%{?dist}
 Summary:    Provide SSH access to initramfs early user space
 URL:        https://github.com/gsauthof/dracut-sshd
@@ -29,18 +29,23 @@ root filesystem and remote access to the Dracut emergency shell
 %install
 mkdir -p %{buildroot}/usr/lib/dracut/modules.d
 cp -r 46sshd %{buildroot}/usr/lib/dracut/modules.d/
+cp -r 99sshd-shadow-fixup %{buildroot}/usr/lib/dracut/modules.d/
 
 %files
 /usr/lib/dracut/modules.d/46sshd/module-setup.sh
 /usr/lib/dracut/modules.d/46sshd/sshd.service
 /usr/lib/dracut/modules.d/46sshd/motd
 /usr/lib/dracut/modules.d/46sshd/profile
+/usr/lib/dracut/modules.d/99sshd-shadow-fixup/module-setup.sh
 %config(noreplace) /usr/lib/dracut/modules.d/46sshd/sshd_config
 %doc README.md
 %doc example/20-wired.network
 %doc example/90-networkd.conf
 
 %changelog
+* Wed Jun 14 2023 Warren Togami <wtogami@gmail.com> - 0.6.6-1
+- 99sshd-shadow-fixup enables ssh pubkey login with disabled password as intended
+
 * Sat May 27 2023 Georg Sauthoff <mail@gms.tf> - 0.6.5-1
 - eliminate tmpfiles and fix Debian/Ubuntu support
 


### PR DESCRIPTION
SSH pubkey login while the password is disabled is common on normal systems.

That normally shows up in /etc/shadow as '^root:!:'

Both '!' and '*' are invalid hashes denoting the password is disabled but sshd with "UsePAM no" differently interprets where '!' disallows logins despite a valid ssh pubkey. If you installed and manually enabled dracut-sshd networking you surely did not intend for it to deny ssh pubkey authentication.

99sshd-shadow-fixup runs after 99base had copied the /etc/shadow entry replacing the '!' character with '*' thereby allowing SSH pubkey login to work as intended.

Fixes: https://github.com/gsauthof/dracut-sshd/issues/19