### PR TITLE
Support OpenSSH 9.8 for openSUSE

### DIFF
--- a/46sshd/module-setup.sh
+++ b/46sshd/module-setup.sh
@@ -61,9 +61,10 @@ install() {
     # Copy ssh helper executables for OpenSSH 9.8+
     # /usr/lib/ssh          -> Arch
     # /usr/lib(64)/misc     -> Gentoo
-    # /usr/libexec/openssh  -> Fedora (possibly)
+    # /usr/libexec/openssh  -> Fedora
+    # /usr/libexec/ssh      -> openSUSE
     local d
-    for d in /usr/lib/ssh /usr/lib64/misc /usr/lib/misc /usr/libexec/openssh ; do
+    for d in /usr/lib/ssh /usr/lib64/misc /usr/lib/misc /usr/libexec/openssh /usr/libexec/ssh ; do
         if [ -f "$d"/sshd-session ]; then
             inst_multiple "$d"/{sshd-session,sftp-server}
             break


### PR DESCRIPTION
Follow-up for 70e5062427a5da3732721ea6d3064d5936d0f0e9

openSUSE already ships `sftp-server` in `/usr/libexec/ssh`, and will ship `sshd-session` in the same directory.

Also, confirmed the path for Fedora Rawhide:

```
root@localhost-live:/home/dev# rpm -ql openssh-server | grep sshd-session
/usr/libexec/openssh/sshd-session
```