### PR TITLE
Update sshd_config to include PubkeyAuthentication option

### DIFF
--- a/46sshd/sshd_config
+++ b/46sshd/sshd_config
@@ -2,6 +2,7 @@ SyslogFacility                  AUTHPRIV
 PermitRootLogin                 prohibit-password
 AuthorizedKeysFile              .ssh/authorized_keys
 AuthenticationMethods           publickey
+PubkeyAuthentication            yes
 UsePAM                          no
 X11Forwarding                   no
 Subsystem sftp                  internal-sftp


### PR DESCRIPTION
Thanks a lot for your work.

During a semi-recent install of fedora 40 (just shortly before the 41 release) I encountered an issue, that I just could not access the unlock shell. After some fiddeling I found out, that the `PubkeyAuthentication` needs to be set to `yes` to make
it work. I found the [RedHat documentation](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/6/html/security_guide/sect-security_guide-encryption-data_in_motion-secure_shell-multi_auth_methods#sect-Security_Guide-Encryption-Data_in_Motion-Secure_Shell-Multi_Auth_Methods) which mentions that the value has to be set explicitly. 

"Use the AuthenticationMethods configuration directive in the `/etc/ssh/sshd`_config file to specify which authentication methods are to be utilized. [...] Note that each of the requested authentication methods needs to be explicitly enabled using a corresponding configuration directive (such as `PubkeyAuthentication`) in the `/etc/ssh/sshd_config` file."

Also the sshd_config(5) manual supports that in the `AuthenticationMethods`  block.

"Note that each authentication method listed should also be explicitly enabled in the configuration."

Interestingly this is not an issue on system that have been running for a while. I could reproduce the issue between multiple Fedora 40 installs.