### PR TITLE
[DOCUMENTATION NEEDED] [REVIEW NEEDED] feat: implement tpm sealed sshd host keys

### DIFF
--- a/46sshd/50-unseal.conf
+++ b/46sshd/50-unseal.conf
@@ -1,0 +1,3 @@
+[Unit]
+Requires=unseal.service
+After=unseal.service

--- a/46sshd/module-setup.sh
+++ b/46sshd/module-setup.sh
@@ -35,6 +35,7 @@ install() {
     local tpm_tempdir
     if [ -n "$dracut_sshd_tpm_pcrs" ]; then
         tpm_tempdir=$(mktemp -d)
+        chmod 700 "$tpm_tempdir"
         ( set -e
             cd "$tpm_tempdir"
             touch key ; chmod 600 key
@@ -74,6 +75,10 @@ install() {
     if [ "$found_host_key" = no ]; then
         dfatal "Didn't find any SSH host key!"
         return 1
+    fi
+
+    if [ -n "$tpm_tempdir" ]; then
+        rm -rf "$tpm_tempdir"
     fi
 
     if [ -e /root/.ssh/dracut_authorized_keys ]; then

--- a/46sshd/unseal.service
+++ b/46sshd/unseal.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Unseal OpenSSH host keys
+DefaultDependencies=no
+#Before=sshd.service
+After=tpm2.target
+Requires=tpm2.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/unseal.sh
+
+#[Install]
+#RequiredBy=sshd.service

--- a/46sshd/unseal.sh
+++ b/46sshd/unseal.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+cd /etc/ssh
+
+touch key ; chmod 600 key
+tpm2_unseal -c key.ctx -p pcr:"$(cat pcrs)" -o key
+
+for enc in *.enc; do
+    base="${enc%.enc}"
+    touch "$base" ; chmod 600 "$base"
+    openssl aes-256-cbc -d -in "$enc" -out "$base" -kfile key -iter 1
+done

--- a/dracut-sshd.spec
+++ b/dracut-sshd.spec
@@ -12,7 +12,7 @@ License:    GPLv3+
 VCS:        {{{ git_dir_vcs }}}
 Source:     {{{ git_dir_pack }}}
 BuildArch:  noarch
-Requires:   dracut-network
+Requires:   dracut-network tpm2-tools openssl
 
 %description
 This Dracut module integrates the OpenSSH sshd into your
@@ -34,6 +34,9 @@ cp -r 46sshd %{buildroot}/usr/lib/dracut/modules.d/
 %dir /usr/lib/dracut/modules.d/46sshd
 /usr/lib/dracut/modules.d/46sshd/module-setup.sh
 /usr/lib/dracut/modules.d/46sshd/sshd.service
+/usr/lib/dracut/modules.d/46sshd/unseal.service
+/usr/lib/dracut/modules.d/46sshd/50-unseal.conf
+/usr/lib/dracut/modules.d/46sshd/unseal.sh
 /usr/lib/dracut/modules.d/46sshd/motd
 /usr/lib/dracut/modules.d/46sshd/profile
 %config(noreplace) /usr/lib/dracut/modules.d/46sshd/sshd_config

--- a/example/50-tpm.conf
+++ b/example/50-tpm.conf
@@ -1,0 +1,2 @@
+dracut_sshd_tpm_pcrs=sha256:0
+add_dracutmodules+=" tpm2-tss "

--- a/test/create-vm.sh
+++ b/test/create-vm.sh
@@ -41,9 +41,10 @@ virt-install --connect qemu:///system \
     --name "$tag" \
     --memory 2048 \
     --network default \
-    --cpu host --vcpus 2 \
+    --cpu host-model --vcpus 2 \
     --graphics none \
     --autoconsole none \
+    --tpm default \
     --import \
     --disk "$dst",format=qco2,bus=virtio \
     --osinfo fedora-unknown \

--- a/test/install-dracut-sshd.sh
+++ b/test/install-dracut-sshd.sh
@@ -18,6 +18,7 @@ $scp  -r 46sshd                 root@"$guest":/usr/lib/dracut/modules.d/
 if [ "$distri" = f ]; then
     $scp  example/20-wired.network  root@"$guest":/etc/systemd/network/20-wired.network
     $scp  example/90-networkd.conf  root@"$guest":/etc/dracut.conf.d/90-networkd.conf
+    $scp  example/50-tpm.conf  root@"$guest":/etc/dracut.conf.d/50-tpm.conf
 
     $ssh root@"$guest" <<EOF
 set -eux


### PR DESCRIPTION
this allows one to verify cryptographically that the initramfs has NOT been modified, and prevents attackers from doing a MITM attack or inserting a keylogger into the initramfs. the key can not be read without booting the machine, and if you modify the initramfs, the key wont be released.

this implementation is somewhat sloppy, as i just need it for my desktop and server right now. even though it passes the tests, please review thoroughly before merging.