### PR TITLE
Explicitly request systemd-networkd installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ under `/etc/dracut-sshd` as `/root` isn't accessible during
 
 Of course, our initramfs image needs network support. The simplest
 way to achieve this is to include [networkd][networkd]. To install
-the networkd dracut module:
+the networkd dracut module and networkd itself:
 
-    # dnf install -y dracut-network
+    # dnf install -y dracut-network systemd-networkd
 
 When installing from copr, `dracut-network` is automatically
 installed as dependency.


### PR DESCRIPTION
The instructions worked for me as-is on Fedora 40 but just this week on a fresh Fedora 41 server installation I bumped into this step failing (I performed all earlier steps, including installing dracut-network):

    # dracut -f -v
    dracut[I]: Executing: /usr/bin/dracut -f -v
    dracut[E]: Module 'systemd-networkd' cannot be installed.

That happened because systemd-networkd wasn't installed by default and nothing pulled it as its dependency.

I'm not entirely sure if this is a Fedora 40/Fedora 41 difference or something.

After installing systemd-networkd I was able to finish the process successfully.