### PR TITLE
network: Allow specifying the config outside of networkd folder

### DIFF
--- a/46sshd/module-setup.sh
+++ b/46sshd/module-setup.sh
@@ -54,6 +54,11 @@ install() {
     /usr/bin/install -m 600 "$authorized_keys" \
             "$initdir/root/.ssh/authorized_keys"
 
+    if [ -e /etc/dracut-sshd/wired.network ]; then
+        /usr/bin/install -m 600 "/etc/dracut-sshd/wired.network" \
+            "$initdir/etc/systemd/network/wired.network"
+    fi
+
     inst_binary /usr/sbin/sshd
     inst_multiple -o /etc/sysconfig/sshd /etc/sysconfig/ssh \
             /etc/sysconfig/dracut-sshd

--- a/README.md
+++ b/README.md
@@ -147,6 +147,11 @@ install_items+=" /etc/systemd/network/20-wired.network "
 add_dracutmodules+=" systemd-networkd "
 ```
 
+Alternatively, if you want the network file to come from outside of:
+`/etc/systemd/network/` then you can put it at `/etc/dracut-sshd/wired.network`
+and it will get included at `/etc/systemd/network/wired.network` automatically.
+In this case, don't add the `install_items` line above.
+
 Alternatively, early boot network connectivity can be configured
 by other means (i.e.  kernel parameters, see below).  However,
 the author of this README strongly recommends to use Networkd


### PR DESCRIPTION
This is useful if you don't want the host to see your normal networkd
config because it might conflict with what you've got going on there
already.