### PR TITLE
Confirm in README it works with openSUSE Leap 16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,7 +559,7 @@ into an encrypted without having to re-install it from scratch.
 - Rocky Linux 8.8, 9, 10.1 (last two by contributors)
 - Gentoo (by a contributor)
 - SUSE (by a contributor)
-- openSUSE Leap 15.5
+- openSUSE Leap 15.5, 16.0
 - Arch (by a contributor)
 - Ubuntu 20.04 LTS
 - Debian 12 (by a contributor)


### PR DESCRIPTION
Thanks for the great tool @gsauthof! I could also confirm it works with openSUSE Leap 16.0. With no any significant issues.

---

```
fire-box:~ # zypper se --installed-only | grep dracut
i+ | dracut                                     | Event driven initramfs infrastructure                                                                                                                                                                                                  | Paket
i+ | dracut-extra                               | Dracut modules usually not required for normal operation                                                                                                                                                                               | Paket
i+ | dracut-sshd                                | Provide SSH access to initramfs early user space                                                                                                                                                                                       | Paket
i+ | dracut-tools                               | Tools to build a local initramfs                                                                                                                                                                                                       | Paket
i  | openSUSE-Leap-16.0-26                      | Recommended update for dracut                                                                                                                                                                                                          | Patch
i  | openSUSE-Leap-16.0-182                     | Recommended update for dracut                                                                                                                                                                                                          | Patch
i  | plymouth-dracut                            | Plymouth related utilities for dracut                                                                                                                                                                                                  | Paket
fire-box:~ # cat /etc/os-release
NAME="openSUSE Leap"
VERSION="16.0"
ID="opensuse-leap"
ID_LIKE="suse opensuse"
VERSION_ID="16.0"
PRETTY_NAME="openSUSE Leap 16.0"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:opensuse:leap:16.0"
BUG_REPORT_URL="https://bugs.opensuse.org"
HOME_URL="https://www.opensuse.org/"
DOCUMENTATION_URL="https://en.opensuse.org/Portal:Leap"
LOGO="distributor-logo-Leap"
```

---

<img width="1962" height="1194" alt="grafik" src="https://github.com/user-attachments/assets/d956ffe1-176a-4ba7-b42a-8f6e4e4da3fe" />

---

<img width="1280" height="488" alt="grafik" src="https://github.com/user-attachments/assets/99cf3d15-c323-498f-a286-05021f95e17a" />
