### PR TITLE
Install root shell binary

### DIFF
--- a/46sshd/module-setup.sh
+++ b/46sshd/module-setup.sh
@@ -17,7 +17,7 @@ depends() {
 
 # called by dracut
 install() {
-    local key_prefix key_type ssh_host_key authorized_keys sshd_config
+    local key_prefix key_type ssh_host_key authorized_keys sshd_config root_shell
     key_prefix=
     if [ "$(find /etc/ssh -maxdepth 1 -name 'dracut_ssh_host_*_key')" ]; then
         key_prefix=dracut_
@@ -85,6 +85,11 @@ install() {
 
     { grep '^sshd:' $dracutsysrootdir/etc/passwd || echo 'sshd:x:74:74:Privilege-separated SSH:/var/empty/sshd:/sbin/nologin'; } >> "$initdir/etc/passwd"
     { grep '^sshd:' $dracutsysrootdir/etc/group  || echo 'sshd:x:74:'; } >> "$initdir/etc/group"
+
+    root_shell="$(sed -n 's#^root:[^:]*:[^:]*:[^:]*:[^:]*:[^:]*:\([^:]*\)$#\1#p' "$dracutsysrootdir/etc/passwd")"
+    if [ -e "$root_shell" ]; then
+        inst_binary "$root_shell"
+    fi
 
     # Create privilege separation directory
     # /var/empty/sshd       -> Fedora, CentOS, RHEL

--- a/README.md
+++ b/README.md
@@ -561,7 +561,7 @@ into an encrypted without having to re-install it from scratch.
 - SUSE (by a contributor)
 - openSUSE Leap 15.5, 16.0
 - Arch (by a contributor)
-- Ubuntu 20.04 LTS
+- Ubuntu 20.04 LTS, 26.04 LTS
 - Debian 12 (by a contributor)
 
 


### PR DESCRIPTION
I have installed `dracut-sshd` on a fresh Ubuntu 26.04 LTS installation. It didn't work immediately, because root shell is `/bin/bash` and while a bash module is present, it is not active by default. This patch fixes this for me. I'm not sure if this is the cleanest way to fix this.