### PR TITLE
Add support for encrypted host keys

### DIFF
--- a/46sshd/module-setup.sh
+++ b/46sshd/module-setup.sh
@@ -31,6 +31,10 @@ install() {
                     "$initdir/etc/ssh/ssh_host_${key_type}_key"
             found_host_key=yes
         fi
+        ssh_host_cred="/etc/credstore.encrypted/dracut_ssh_host_${key_type}_key"
+        if [ -f "$ssh_host_cred" ]; then
+            inst_simple "$ssh_host_cred"
+        fi
     done
     if [ "$found_host_key" = no ]; then
         dfatal "Didn't find any SSH host key!"
@@ -118,4 +122,3 @@ install() {
 
     return 0
 }
-

--- a/46sshd/sshd.service
+++ b/46sshd/sshd.service
@@ -20,6 +20,19 @@ EnvironmentFile=-/etc/sysconfig/sshd
 EnvironmentFile=-/etc/sysconfig/ssh
 EnvironmentFile=-/etc/sysconfig/dracut-sshd
 
+# Import SSH host keys from systemd credentials if available.
+# This allows storing host keys encrypted (e.g., bound to TPM PCRs)
+# in the EFI system partition or initrd.
+ImportCredential=dracut_ssh_host_*
+
+# If credentials were successfully imported, copy them to the
+# expected locations, overriding any unencrypted host keys.
+# If credentials fail to unseal or are missing, the existing
+# unencrypted host keys will be used as a fallback.
+ExecStartPre=-/bin/cp ${CREDENTIALS_DIRECTORY}/dracut_ssh_host_ecdsa_key /etc/ssh/ssh_host_ecdsa_key
+ExecStartPre=-/bin/cp ${CREDENTIALS_DIRECTORY}/dracut_ssh_host_ed25519_key /etc/ssh/ssh_host_ed25519_key
+ExecStartPre=-/bin/cp ${CREDENTIALS_DIRECTORY}/dracut_ssh_host_rsa_key /etc/ssh/ssh_host_rsa_key
+
 # Start command requires the `-e` option if and only if `Type=simple`
 # is configured, see above.
 ExecStart=/usr/sbin/sshd -D $SSHD_OPTS $OPTIONS $CRYPTO_POLICY

--- a/46sshd/sshd.service
+++ b/46sshd/sshd.service
@@ -29,9 +29,7 @@ ImportCredential=dracut_ssh_host_*
 # expected locations, overriding any unencrypted host keys.
 # If credentials fail to unseal or are missing, the existing
 # unencrypted host keys will be used as a fallback.
-ExecStartPre=-/bin/cp ${CREDENTIALS_DIRECTORY}/dracut_ssh_host_ecdsa_key /etc/ssh/ssh_host_ecdsa_key
-ExecStartPre=-/bin/cp ${CREDENTIALS_DIRECTORY}/dracut_ssh_host_ed25519_key /etc/ssh/ssh_host_ed25519_key
-ExecStartPre=-/bin/cp ${CREDENTIALS_DIRECTORY}/dracut_ssh_host_rsa_key /etc/ssh/ssh_host_rsa_key
+ExecStartPre=-/bin/sh -c 'for k in ecdsa ed25519 rsa; do [ -f "${CREDENTIALS_DIRECTORY}/dracut_ssh_host_$${k}_key" ] && cp "${CREDENTIALS_DIRECTORY}/dracut_ssh_host_$${k}_key" "/etc/ssh/ssh_host_$${k}_key"; done'
 
 # Start command requires the `-e` option if and only if `Type=simple`
 # is configured, see above.

--- a/README.md
+++ b/README.md
@@ -258,6 +258,40 @@ host key in the initramfs image  provides no value to the
 attacker given that the root filesystem is fully encrypted (and
 that the host key isn't reused in the replacement system).
 
+### Encrypted Host Keys (TPM)
+
+To prevent the extraction of unencrypted host keys from the
+initramfs, you can store host keys as encrypted systemd
+credentials protected by a [TPM]. This is useful when building a
+signed Unified Kernel Image (UKI) and binding to TPM PCRs.
+
+You can create encrypted system credentials using `systemd-creds`
+and store them in `/etc/credstore.encrypted/` which dracut-sshd
+will include in the initramfs. systemd-boot also supports storing
+them in the EFI system partition under `loader/credentials/` with
+a `.cred` suffix.
+
+The following credential names are supported:
+
+- `dracut_ssh_host_ecdsa_key`
+- `dracut_ssh_host_ed25519_key`
+- `dracut_ssh_host_rsa_key`
+
+For example, to encrypt an Ed25519 host key and bind it to TPM
+PCRs 7 (secure boot state) and 14 (machine owner key):
+
+    ssh-keygen -f /etc/ssh/dracut_ssh_host_ed25519_key -N '' -t ed25519
+    ssh-keygen -f /etc/ssh/dracut_ssh_tpm_host_ed25519_key -N '' -t ed25519
+    systemd-creds encrypt --with-key=tpm2 --tpm2-pcrs=7+14 \
+        /etc/ssh/dracut_ssh_tpm_host_ed25519_key \
+        /etc/credstore.encrypted/dracut_ssh_host_ed25519_key
+
+dracut-sshd still requires unencrypted host keys in the initramfs
+in case encrypted host keys fail to unseal (e.g., due to PCR
+change or a broken TPM). You can generate at least one
+unencrypted key (e.g., `/etc/ssh/dracut_ssh_host_ed25519_key`) to
+avoid including the system's host keys as the fallback.
+
 ## Timeout
 
 With recent Fedora versions (e.g. Fedora 28) a cryptsetup


### PR DESCRIPTION
Add support for TPM-backed systemd credentials to store encrypted SSH host keys.

Changes:

- Include `/etc/credstore.encrypted/dracut_ssh_host_*` files in the initramfs when present
- Use `ImportCredential` and `ExecStartPre` in the sshd service to load credentials at runtime, copying unsealed keys over any unencrypted fallback
- Update README

Fixes #125.